### PR TITLE
disable bitcode when building, note in Readme & regen prebuilt

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,7 @@ cmake -G Xcode
   - set `Build Active Architectures Only` to `NO`
   - set `Deployment Target` to the base iOS version to support
   - set `Inline Methods Hidden` and `Symbols Hidden by Default` to `YES`
+  - set `Enable Bitcode` to `NO`
 
 #### 4. Build avrocpp_s for iOS simulator and Device targets
 ```


### PR DESCRIPTION
Ran into an issue related with a warning related to `duplicate symbol _llvm.embedded.module` when building in Xcode 6.

This is apparently a symptom of bitcode use and Xcode 6.4.

This PR mentions bitcode in the readme and updates the prebuilt
